### PR TITLE
Fix duplicate treasure hunter messages when restarting

### DIFF
--- a/src/PawsyApp/PawsyCore/Pawsy.cs
+++ b/src/PawsyApp/PawsyCore/Pawsy.cs
@@ -398,4 +398,15 @@ public class Pawsy
 
         throw new Exception($"Unreachable code in AddOrGetGuild. ID: {ID}");
     }
+
+    public void OnCloseApp(object? sender, ConsoleCancelEventArgs args)
+    {
+        LogAppendLine(Name, $"Deactivating {Guilds.Count} guilds");
+        foreach (var item in Guilds.Values)
+        {
+            item.OnDeactivate();
+        }
+
+        LogAppendLine(Name, "Closing Pawsy");
+    }
 }

--- a/src/PawsyApp/Program.cs
+++ b/src/PawsyApp/Program.cs
@@ -17,6 +17,9 @@ public class PawsyProgram
         Console.WriteLine($"Pawsy version {informationalVersion}");
 
         Pawsy pawsy = new();
+
+        Console.CancelKeyPress += pawsy.OnCloseApp;
+
         await Task.Delay(-1);
     }
 }

--- a/src/PawsyModules/Meowboard/Meowboard.cs
+++ b/src/PawsyModules/Meowboard/Meowboard.cs
@@ -61,6 +61,9 @@ public class MeowBoardModule : GuildModule
             owner.OnGuildButtonClicked -= ButtonCallback;
             Enabled = false;
         }
+
+        if (!TreasureGame.GameActive || TreasureGame.gameMessage is null) return;
+        TreasureGame.gameMessage.DeleteAsync();
     }
 
     public override SlashCommandBundle OnCommandsDeclared(SlashCommandBuilder builder)
@@ -246,11 +249,11 @@ public class MeowBoardModule : GuildModule
         protected WeakReference<MeowBoardModule> Owner = new(Owner);
         protected ConcurrentBag<ulong> TreasureHunters = [];
         protected ulong FirstResponder = 0;
-        protected bool GameActive = false;
+        public bool GameActive = false;
         public object LockRoot = new();
         internal DateTime NextGameAt = DateTime.Now.AddSeconds(10f);
         protected DateTime GameEndsAt = DateTime.Now.AddSeconds(10f);
-        protected RestUserMessage? gameMessage;
+        public RestUserMessage? gameMessage;
         protected int currentLine = 0;
 
         protected string[] TreasureMessages = [

--- a/src/PawsyModules/Meowboard/Meowboard.cs
+++ b/src/PawsyModules/Meowboard/Meowboard.cs
@@ -53,7 +53,7 @@ public class MeowBoardModule : GuildModule
         }
     }
 
-    public override void OnDeactivate()
+    public override async void OnDeactivate()
     {
         if (Owner.TryGetTarget(out var owner))
         {
@@ -63,7 +63,7 @@ public class MeowBoardModule : GuildModule
         }
 
         if (!TreasureGame.GameActive || TreasureGame.gameMessage is null) return;
-        TreasureGame.gameMessage.DeleteAsync();
+        await TreasureGame.gameMessage.DeleteAsync();
     }
 
     public override SlashCommandBundle OnCommandsDeclared(SlashCommandBuilder builder)

--- a/src/PawsyModules/Meowboard/Meowboard.cs
+++ b/src/PawsyModules/Meowboard/Meowboard.cs
@@ -249,11 +249,11 @@ public class MeowBoardModule : GuildModule
         protected WeakReference<MeowBoardModule> Owner = new(Owner);
         protected ConcurrentBag<ulong> TreasureHunters = [];
         protected ulong FirstResponder = 0;
-        public bool GameActive = false;
+        internal bool GameActive = false;
         public object LockRoot = new();
         internal DateTime NextGameAt = DateTime.Now.AddSeconds(10f);
         protected DateTime GameEndsAt = DateTime.Now.AddSeconds(10f);
-        public RestUserMessage? gameMessage;
+        internal RestUserMessage? gameMessage;
         protected int currentLine = 0;
 
         protected string[] TreasureMessages = [


### PR DESCRIPTION
When closing Pawsy with Ctrl + C it now deactivates all guilds, this was done to fix an issue in treasure hunter that duplicates messages.

Currently I only tested this on windows but I assume the server that runs Pawsy is on Linux so more testing probably is needed.
During my testing the deletion of the message sometimes failed (with no errors) it seemed to happen inconsistently (I blame windows)

