### PR TITLE
Adds safe close

### DIFF
--- a/src/PawsyApp/PawsyApp.csproj
+++ b/src/PawsyApp/PawsyApp.csproj
@@ -11,7 +11,7 @@
     <LangVersion>latest</LangVersion>
     <PublishSingleFile>true</PublishSingleFile>
 
-    <Version>2.2.1.0</Version>
+    <Version>2.2.2.0</Version>
 
     <ProjectDepsFileName>$(Product).deps.json</ProjectDepsFileName>
     <RootNamespace>$(Product)</RootNamespace>

--- a/src/PawsyApp/PawsyCore/Pawsy.cs
+++ b/src/PawsyApp/PawsyCore/Pawsy.cs
@@ -405,15 +405,15 @@ public class Pawsy
         throw new Exception($"Unreachable code in AddOrGetGuild. ID: {ID}");
     }
 
-    public void OnCloseApp(object? sender, ConsoleCancelEventArgs args)
+    public void Destroy()
     {
-        LogAppendLine(Name, $"Destroying {Guilds.Count} guilds");
+        LogAppendLine(Name, "Pawsy is shutting down");
+
         foreach (var item in Guilds.Values)
         {
-            item.OnDeactivate();
             item.Destroy();
         }
 
-        LogAppendLine(Name, "Closing Pawsy");
+        LogAppendLine(Name, $"Pawsy has shut down {Guilds.Count} guilds safely");
     }
 }

--- a/src/PawsyApp/Program.cs
+++ b/src/PawsyApp/Program.cs
@@ -17,9 +17,24 @@ public class PawsyProgram
         Console.WriteLine($"Pawsy version {informationalVersion}");
 
         Pawsy pawsy = new();
+        bool running = true;
 
-        Console.CancelKeyPress += pawsy.OnCloseApp;
+        while (running)
+        {
+            await Task.Delay(100);
 
-        await Task.Delay(-1);
+            if (Console.KeyAvailable)
+            {
+                var key = Console.ReadKey(intercept: true);
+
+                if (key.Key == ConsoleKey.Q && key.Modifiers == ConsoleModifiers.Control)
+                {
+                    pawsy.Destroy();
+                    running = false;
+                }
+            }
+        }
+
+        Console.WriteLine("Program exit");
     }
 }


### PR DESCRIPTION
### Features
- Removes event based close handling
- Adds explicit check for CTRL+Q quit command
- Removes support for CTRL+C break handling. This is not supported and will break modules

### Reasons
Pawsy lives in async land and a console event for CTRL+C simply does not stay in-closure long enough and async tasks get reaped before they finish. This explicit implementation keeps us in sync land and forces the process to complete before gracefully exiting. Exceptions and explicit termination of the console/process will still break things but that is to be expected.