### PR TITLE
Allow thread owners to use PinBot

### DIFF
--- a/src/PawsyModules/PinBot/PinBot.cs
+++ b/src/PawsyModules/PinBot/PinBot.cs
@@ -144,6 +144,19 @@ public class PinBot : GuildModule
         return false;
     }
 
+    protected bool CanPinMessage(SocketGuildUser user, SocketTextChannel channel)
+    {
+        if (HasPermissions(user)) return true;
+
+        if (channel is not SocketThreadChannel tChannel)
+            return false;
+
+        if (tChannel.Owner.GuildUser != user)
+            return false;
+
+        return true;
+    }
+
     private Task ModuleCommandHandler(SocketSlashCommand command)
     {
 
@@ -184,7 +197,7 @@ public class PinBot : GuildModule
             ("MessageID", MessageID)
         ]);
 
-        if (!HasPermissions(gUser))
+        if (!CanPinMessage(gUser, tChannel))
             return command.RespondAsync("You don't have permission to use this command, meow", ephemeral: true);
 
         switch (commandName)

--- a/src/PawsyModules/PinBot/PinBot.cs
+++ b/src/PawsyModules/PinBot/PinBot.cs
@@ -133,8 +133,10 @@ public class PinBot : GuildModule
         return (cID, mID);
     }
 
-    protected bool HasPermissions(SocketGuildUser user)
+    protected bool HasPermissions(SocketGuildUser user, SocketTextChannel channel)
     {
+        if (user.GetPermissions(channel).ManageMessages) return true;
+
         foreach (var role in user.Roles)
         {
             if (Settings.RolesWithPerms.ContainsKey(role.Id))
@@ -146,7 +148,7 @@ public class PinBot : GuildModule
 
     protected bool CanPinMessage(SocketGuildUser user, SocketTextChannel channel)
     {
-        if (HasPermissions(user)) return true;
+        if (HasPermissions(user, channel)) return true;
 
         if (channel is not SocketThreadChannel tChannel)
             return false;


### PR DESCRIPTION
Allows thread owners to pin any message within their thread, also allows users with the Manage Messages permission to use the pin bot (doesn't do much)

Closes #14