### PR TITLE
PinBot auto pin

### DIFF
--- a/src/PawsyModules/PinBot/PinBot.cs
+++ b/src/PawsyModules/PinBot/PinBot.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Channels;
 using System.Threading.Tasks;
 
 using Discord;
@@ -74,12 +75,12 @@ public class PinBot : GuildModule
             new SlashCommandOptionBuilder()
             .WithType(ApplicationCommandOptionType.Role)
             .WithName("pin-role")
-            .WithDescription("Add or remove a role's permission to use pin commands")
+            .WithDescription("Add or remove a role's permission to use pin commands"))
         .AddOption(
             new SlashCommandOptionBuilder()
             .WithType(ApplicationCommandOptionType.Channel)
             .WithName("auto-pin-channel")
-            .WithDescription("Add or remove a forum channel to auto pin its first message")));
+            .WithDescription("Add or remove a forum channel to auto pin its first message"));
     }
 
     public override Task OnConfigUpdated(SocketSlashCommand command, SocketSlashCommandDataOption options)

--- a/src/PawsyModules/PinBot/PinBot.cs
+++ b/src/PawsyModules/PinBot/PinBot.cs
@@ -29,7 +29,7 @@ public class PinBot : GuildModule
     {
         if (Owner.TryGetTarget(out var owner))
         {
-            //Add owner.Event callbacks here
+            owner.OnGuildThreadCreated += ThreadCreated;
         }
     }
 

--- a/src/PawsyModules/PinBot/PinBot.cs
+++ b/src/PawsyModules/PinBot/PinBot.cs
@@ -109,6 +109,22 @@ public class PinBot : GuildModule
                 (Settings as ISettings).Save<PinBotSettings>(this);
 
                 return Task.CompletedTask;
+            case "auto-pin-channel":
+                if (optionValue is not SocketForumChannel channel)
+                    return command.RespondAsync("Only forum channels please");
+                if (Settings.AutoPinChannels.ContainsKey(channel.Id))
+                {
+                    Settings.AutoPinChannels.Remove(channel.Id, out var _);
+                    command.RespondAsync($"Removed auto pin from {channel.Mention}");
+                }
+                else
+                {
+                    Settings.AutoPinChannels.TryAdd(channel.Id, true);
+                    command.RespondAsync($"Added auto pin to {channel.Mention}");
+                }
+                (Settings as ISettings).Save<PinBotSettings>(this);
+
+                return Task.CompletedTask;
             default:
                 return command.RespondAsync("Something went wrong in HandleConfig", ephemeral: true); ;
         }

--- a/src/PawsyModules/PinBot/PinBot.cs
+++ b/src/PawsyModules/PinBot/PinBot.cs
@@ -75,7 +75,11 @@ public class PinBot : GuildModule
             .WithType(ApplicationCommandOptionType.Role)
             .WithName("pin-role")
             .WithDescription("Add or remove a role's permission to use pin commands")
-        );
+        .AddOption(
+            new SlashCommandOptionBuilder()
+            .WithType(ApplicationCommandOptionType.Channel)
+            .WithName("auto-pin-channel")
+            .WithDescription("Add or remove a forum channel to auto pin its first message")));
     }
 
     public override Task OnConfigUpdated(SocketSlashCommand command, SocketSlashCommandDataOption options)

--- a/src/PawsyModules/PinBot/PinBot.cs
+++ b/src/PawsyModules/PinBot/PinBot.cs
@@ -112,6 +112,7 @@ public class PinBot : GuildModule
             case "auto-pin-channel":
                 if (optionValue is not SocketForumChannel channel)
                     return command.RespondAsync("Only forum channels please");
+
                 if (Settings.AutoPinChannels.ContainsKey(channel.Id))
                 {
                     Settings.AutoPinChannels.Remove(channel.Id, out var _);
@@ -122,6 +123,7 @@ public class PinBot : GuildModule
                     Settings.AutoPinChannels.TryAdd(channel.Id, true);
                     command.RespondAsync($"Added auto pin to {channel.Mention}");
                 }
+
                 (Settings as ISettings).Save<PinBotSettings>(this);
 
                 return Task.CompletedTask;
@@ -264,13 +266,18 @@ public class PinBot : GuildModule
     {
         if (Settings is null)
             return;
+
         if (!Settings.AutoPinChannels.ContainsKey(channel.ParentChannel.Id))
             return;
+
         if (channel.ParentChannel is not SocketForumChannel)
             return;
+
         var messages = await channel.GetMessagesAsync(1).FlattenAsync();
+
         if (messages.FirstOrDefault() is not IUserMessage message)
             return;
+
         _ = LogAppendContext("PinBot AutoPin accessed", [
             ("ThreadID", channel.Id),
             ("ThreadName", channel.Name),
@@ -280,6 +287,7 @@ public class PinBot : GuildModule
             ("User", channel.Owner.DisplayName),
             ("MessageContent", message.CleanContent)
         ]);
+
         try
         {
             await message.PinAsync();

--- a/src/PawsyModules/PinBot/Settings/PinBotSettings.cs
+++ b/src/PawsyModules/PinBot/Settings/PinBotSettings.cs
@@ -8,4 +8,6 @@ public class PinBotSettings() : ISettings
 {
     [JsonInclude]
     internal ConcurrentDictionary<ulong, bool> RolesWithPerms = [];
+
+    internal ConcurrentDictionary<ulong, bool> AutoPinChannels = [];
 }

--- a/src/PawsyModules/PinBot/Settings/PinBotSettings.cs
+++ b/src/PawsyModules/PinBot/Settings/PinBotSettings.cs
@@ -9,5 +9,6 @@ public class PinBotSettings() : ISettings
     [JsonInclude]
     internal ConcurrentDictionary<ulong, bool> RolesWithPerms = [];
 
+    [JsonInclude]
     internal ConcurrentDictionary<ulong, bool> AutoPinChannels = [];
 }


### PR DESCRIPTION
Pawsy can now automatically pin the first message of a forum channel thread if said forum channel is specified in the config named `auto-pin-channel`.
It can only do that for forum channels. (it will reject anything else)